### PR TITLE
Fix analysis sampler loading

### DIFF
--- a/analysis/DataLoader.cc
+++ b/analysis/DataLoader.cc
@@ -212,7 +212,7 @@ void DataLoader::BuildEventBranchNameList()
     }
   
   if (mt->GetEntries() == 0)
-    {// no model tree was stored, so we don't know which branches are which type of smaplers
+    {// no model tree was stored, so we don't know which branches are which type of samplers
       // alternatively, inspect the branches of the event tree and get their class names.
       TTree* et = (TTree*)f->Get("Event");
       if (!et)
@@ -221,9 +221,15 @@ void DataLoader::BuildEventBranchNameList()
           delete f;
           throw RBDSException(__METHOD_NAME__, "No Event tree in file - likely a corrupted file.");
         }
-      const std::set<std::string> samplerClasses = {"BDSOutputROOTEventSampler", "BDSOutputROOTEventSamplerC", "BDSOutputROOTEventSamplerS"};
+      const std::set<std::string> samplerClasses = {"BDSOutputROOTEventSampler",
+                                                    "BDSOutputROOTEventSampler<float>",
+                                                    "BDSOutputROOTEventSampler<double>",
+                                                    "BDSOutputROOTEventSamplerC",
+                                                    "BDSOutputROOTEventSamplerS"};
       std::map<std::string, std::vector<std::string>*> vectors = {
         {"BDSOutputROOTEventSampler", &allSamplerNames},
+        {"BDSOutputROOTEventSampler<float>", &allSamplerNames},
+        {"BDSOutputROOTEventSampler<double>", &allSamplerNames},
         {"BDSOutputROOTEventSamplerC", &allCSamplerNames},
         {"BDSOutputROOTEventSamplerS", &allSSamplerNames},
       };

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -48,7 +48,7 @@ New Features
 
 * :code:`autoColour=1` now works for all collimators and target elements. If turned on, the
   colour of the element in the visualiser will be given by the material.
-* GDML exports from BDSIM now include auxliary colour information that can be handled by
+* GDML exports from BDSIM now include auxiliary colour information that can be handled by
   pyg4ometry and also be BDSIM if the same file is loaded in again.
 
 **Physics**
@@ -98,6 +98,8 @@ Bug Fixes
 * :code:`--exportGeometryTo` executable option used to build up relative paths with respect to the
   input file and not the executable location. This has been fixed to be relative to the executable
   location. Noticeable if executing BDSIM from a different directory from the main input file.
+* Fixed the loading of samplers with DataLoader (used when using :code:`pybdsim.Data.Load`) when
+  no model tree was stored. The samplers would not be identified in the past.
 
 
 Output Changes


### PR DESCRIPTION
When loading output data in pybdsim with `pybdsim.Data.Load`, the bdsim/analysis/DataLoader class is used. If the model tree is present, it uses the vector of sampler names to setup the branch loading. If the model isn't present (i.e. minimal data), then it does it by comparing the branch class name (from ROOT) to a list of known classes. There was a bug in that the untemplated class name was matched only. So the branches were never identified as samplers and never loaded.

This fix identifies them but puts them in the one correct vector.