### PR TITLE
Throw an exception is a nan or +-inf value is given in a field map.

### DIFF
--- a/include/BDSFieldLoaderBDSIM.hh
+++ b/include/BDSFieldLoaderBDSIM.hh
@@ -76,9 +76,10 @@ private:
   /// Process on line of data. Index of 0 corresponds to a default value of field of 0.
   /// This allows various dimensional loading to use the same function.
   void ProcessData(const std::string& line,
-		   const unsigned long xIndex,
-		   const unsigned long yIndex = 0,
-		   const unsigned long zIndex = 0);
+                   const unsigned long xIndex,
+                   const unsigned long yIndex,
+                   const unsigned long zIndex,
+                   unsigned long long currentLineNumber);
 
   /// Templated iostream for std::ifstream and gzstream as well
   T file;

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -86,6 +86,10 @@ General Updates
   is different and so the component must be uniquely constructed to have a different field.
 * The time coordinate is now loaded and applied to each particle when loading a bdsim output
   sampler as a distribution.
+* An exception will now be thrown if a field map is loaded containing NAN or +-INF values. In
+  the past, these would be simply loaded and propagated through to tracking resulting in a stuck
+  particle in Geant4.
+
 
 Bug Fixes
 ---------

--- a/src/BDSFieldLoaderBDSIM.cc
+++ b/src/BDSFieldLoaderBDSIM.cc
@@ -375,7 +375,7 @@ void BDSFieldLoaderBDSIM<T>::Load(const G4String& fileName,
                       currentLineNumber++;
                       if (std::all_of(line.begin(), line.end(), isspace))
                         {continue;}
-                      ProcessData(line, xIndex, yIndex, zIndex); // changes member fv
+                      ProcessData(line, xIndex, yIndex, zIndex, currentLineNumber); // changes member fv
                       (*result)(i, j, k, l) = fv;
                       float mag = fv.mag();
                       maximumFieldValue = std::max(maximumFieldValue, mag);
@@ -400,7 +400,7 @@ void BDSFieldLoaderBDSIM<T>::Load(const G4String& fileName,
                       currentLineNumber++;
                       if (std::all_of(line.begin(), line.end(), isspace))
                         {continue;}
-                      ProcessData(line, xIndex, yIndex, zIndex); // changes member fv
+                      ProcessData(line, xIndex, yIndex, zIndex, currentLineNumber); // changes member fv
                       (*result)(i, j, k, l) = fv;
                       float mag = fv.mag();
                       maximumFieldValue = std::max(maximumFieldValue, mag);
@@ -420,7 +420,8 @@ template <class T>
 void BDSFieldLoaderBDSIM<T>::ProcessData(const std::string& line,
                                          const unsigned long xIndex,
                                          const unsigned long yIndex,
-                                         const unsigned long zIndex)
+                                         const unsigned long zIndex,
+                                         unsigned long long currentLineNumber)
 {
   std::istringstream liness(line);
   G4float value = 0;
@@ -432,6 +433,8 @@ void BDSFieldLoaderBDSIM<T>::ProcessData(const std::string& line,
       liness >> value;
       if (i < indexOfFirstFieldValue)// coordinates before this index
         {value *= CLHEP::cm;}
+      if (!std::isfinite(value))
+        {throw BDSException("BDSFieldLoaderBDSIM>", "a not-finite value was found on line " + std::to_string(currentLineNumber));}
       lineData[i] = value;
     }
   


### PR DESCRIPTION
Any NAN or +-INF values would be loaded and propagated through to tracking leading to unexpected behaviour.

This doesn't show much overhead at all, which is good and worth it.