### PR TITLE
Link for collimator tip jaw.

### DIFF
--- a/include/BDSIMLink.hh
+++ b/include/BDSIMLink.hh
@@ -105,6 +105,21 @@ public:
                            double crystalAngle  = 0,
 			   bool   sampleIn      = false);
 
+    int AddLinkCollimatorTipJaw(const std::string& collimatorName,
+                                const std::string& materialName,
+                                const std::string& tipMaterialName,
+                                double tipThickness,
+                                double length,
+                                double halfApertureLeft,
+                                double halfApertureRight,
+                                double rotation,
+                                double xOffset,
+                                double yOffset,
+                                double jawTiltLeft = 0.0,
+                                double jawTiltRight = 0.0,
+                                bool   buildLeftJaw  = true,
+                                bool   buildRightJaw = true);
+
   BDSHitsCollectionSamplerLink* SamplerHits() const;
   void ClearSamplerHits() {runAction->ClearSamplerHits();}
   

--- a/include/BDSLinkDetectorConstruction.hh
+++ b/include/BDSLinkDetectorConstruction.hh
@@ -85,7 +85,6 @@ public:
                                 G4double yOffset,
                                 G4double jawTiltLeft = 0.0,
                                 G4double jawTiltRight = 0.0,
-                                G4double tipThickness = 0.0,
                                 G4bool   buildLeftJaw  = true,
                                 G4bool   buildRightJaw = true);
   

--- a/include/BDSLinkDetectorConstruction.hh
+++ b/include/BDSLinkDetectorConstruction.hh
@@ -76,6 +76,7 @@ public:
   G4int AddLinkCollimatorTipJaw(const std::string& collimatorName,
                                 const std::string& materialName,
                                 const std::string& tipMaterialName,
+                                G4double tipThickness,
                                 G4double length,
                                 G4double halfApertureLeft,
                                 G4double halfApertureRight,

--- a/src/BDSIMLink.cc
+++ b/src/BDSIMLink.cc
@@ -552,6 +552,53 @@ int BDSIMLink::AddLinkCollimatorJaw(const std::string& collimatorName,
   return (int)linkID;
 }
 
+int BDSIMLink::AddLinkCollimatorTipJaw(const std::string& collimatorName,
+				     const std::string& materialName,
+             const std::string& tipMaterialName,
+             double tipThickness,
+				     double length,
+				     double halfApertureLeft,
+				     double halfApertureRight,
+				     double rotation,
+				     double xOffset,
+				     double yOffset,
+                     double jawTiltLeft,
+                     double jawTiltRight,
+				     bool   buildLeftJaw,
+				     bool   buildRightJaw)
+{
+  G4GeometryManager* gm = G4GeometryManager::GetInstance();
+  if (gm->IsGeometryClosed())
+    {gm->OpenGeometry();}
+
+  G4int linkID = construction->AddLinkCollimatorTipJaw(collimatorName,
+				     materialName,
+             tipMaterialName,
+             tipThickness,
+				     length,
+				     halfApertureLeft,
+				     halfApertureRight,
+				     rotation,
+				     xOffset,
+				     yOffset,
+                     jawTiltLeft,
+                     jawTiltRight,
+				     buildLeftJaw,
+				     buildRightJaw);
+  // update this class's nameToElementIndex map
+  nameToElementIndex = construction->NameToElementIndex();
+  linkIDToBeamlineIndex = construction->LinkIDToBeamlineIndex();
+  
+  if (bdsOutput)
+    {bdsOutput->UpdateSamplers();}
+
+  /// Close the geometry in preparation for running - everything is now fixed.
+  G4bool bCloseGeometry = gm->CloseGeometry();
+  if (!bCloseGeometry)
+    {throw BDSException(__METHOD_NAME__, "error - geometry not closed.");}
+  return (int)linkID;
+}
+
 BDSHitsCollectionSamplerLink* BDSIMLink::SamplerHits() const
 {
   return runAction ? runAction->SamplerHits() : nullptr;

--- a/src/BDSLinkDetectorConstruction.cc
+++ b/src/BDSLinkDetectorConstruction.cc
@@ -359,7 +359,6 @@ G4int BDSLinkDetectorConstruction::AddLinkCollimatorTipJaw(const std::string& co
                                                           G4double yOffset,
                                                           G4double jawTiltLeft,
                                                           G4double jawTiltRight,
-                                                          G4double tipThickness,
                                                           G4bool   buildLeftJaw,
                                                           G4bool   buildRightJaw)
 {

--- a/src/BDSLinkDetectorConstruction.cc
+++ b/src/BDSLinkDetectorConstruction.cc
@@ -350,6 +350,7 @@ G4int BDSLinkDetectorConstruction::AddLinkCollimatorJaw(const std::string& colli
 G4int BDSLinkDetectorConstruction::AddLinkCollimatorTipJaw(const std::string& collimatorName,
                                                           const std::string& materialName,
                                                           const std::string& tipMaterialName,
+                                                          G4double tipThickness,
                                                           G4double length,
                                                           G4double halfApertureLeft,
                                                           G4double halfApertureRight,

--- a/src/BDSLinkDetectorConstruction.cc
+++ b/src/BDSLinkDetectorConstruction.cc
@@ -385,7 +385,7 @@ G4int BDSLinkDetectorConstruction::AddLinkCollimatorTipJaw(const std::string& co
     el.l        = length / CLHEP::m;
     el.xsizeLeft  = halfApertureLeft / CLHEP::m;
     el.xsizeRight = halfApertureRight / CLHEP::m;
-    el.ysize    = 0.2; // half height
+    el.ysize    = 0.006; // half height
     el.tilt     = rotation / CLHEP::rad;
     el.offsetX  = xOffset / CLHEP::m;
     el.offsetY  = yOffset / CLHEP::m;


### PR DESCRIPTION
This pull request updates the `BDSIMLink` to support the newly implemented `CollimatorTipJaw` ([commit 115740f](https://github.com/bdsim-collaboration/bdsim/commit/115740f828a56427e7c530a22901b9768cf273b6)) in the Xsuite-BDSIM coupling via collimasim.

The collimasim library has been updated accordingly to exploit the new features introduced in this pull request ([collimasim](https://gitlab.cern.ch/anabramo/collimasim) - [commit 33eb9c14](https://gitlab.cern.ch/anabramo/collimasim/-/commit/33eb9c14d5d55842831dcf2c64d6403a5021e7f7).