### PR TITLE
Trajectory local pxpypz fix

### DIFF
--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -84,7 +84,7 @@ General Updates
   but also the nominal rigidity at that point in the beamline. This is because if, say, a quadrupole
   is used later in the beamline after acceleration with the same `k1`, the actual field gradient
   is different and so the component must be uniquely constructed to have a different field.
-* The time coordinate is now loaded and applied to each particle when loading a bdsim output
+* The time coordinate is now loaded and applied to each particle when loading a BDSIM output
   sampler as a distribution.
 * An exception will now be thrown if a field map is loaded containing NAN or +-INF values. In
   the past, these would be simply loaded and propagated through to tracking resulting in a stuck
@@ -104,6 +104,9 @@ Bug Fixes
   location. Noticeable if executing BDSIM from a different directory from the main input file.
 * Fixed the loading of samplers with DataLoader (used when using :code:`pybdsim.Data.Load`) when
   no model tree was stored. The samplers would not be identified in the past.
+* Fix the :code:`Event.Trajectory.pxpypz` variable in the output. It was implemented
+  incorrectly in code and was not the correct data. It is now components of the momentum
+  vector (absolute) in GeV/c in a frame local to that element as it should be.
 
 
 Output Changes

--- a/src/BDSOutputROOTEventTrajectory.cc
+++ b/src/BDSOutputROOTEventTrajectory.cc
@@ -270,9 +270,7 @@ void BDSOutputROOTEventTrajectory::FillIndividualTrajectory(IndividualTrajectory
   
   // Position
   G4ThreeVector pos = point->GetPosition();
-  itj.XYZ.emplace_back(TVector3(pos.getX() / CLHEP::m,
-                                pos.getY() / CLHEP::m,
-                                pos.getZ() / CLHEP::m));
+  itj.XYZ.emplace_back(pos.getX() / CLHEP::m, pos.getY() / CLHEP::m, pos.getZ() / CLHEP::m);
   
   G4VPhysicalVolume* vol = auxNavigator->LocateGlobalPointAndSetup(pos,nullptr,true,true,true);
   BDSPhysicalVolumeInfo* theInfo = BDSPhysicalVolumeInfoRegistry::Instance()->GetInfo(vol);
@@ -291,9 +289,7 @@ void BDSOutputROOTEventTrajectory::FillIndividualTrajectory(IndividualTrajectory
   itj.postWeight.push_back(point->GetPostWeight());
   itj.energyDeposit.push_back(point->GetEnergyDeposit() / CLHEP::GeV);
   G4ThreeVector mom = point->GetPreMomentum() / CLHEP::GeV;
-  itj.PXPYPZ.emplace_back(TVector3(mom.getX(),
-                                   mom.getY(),
-                                   mom.getZ()));
+  itj.PXPYPZ.emplace_back(mom.getX(), mom.getY(), mom.getZ());
   itj.S.push_back(point->GetPreS() / CLHEP::m);
   itj.T.push_back(point->GetPreGlobalTime() / CLHEP::ns);
   itj.kineticEnergy.push_back(point->GetKineticEnergy() / CLHEP::GeV);
@@ -304,12 +300,8 @@ void BDSOutputROOTEventTrajectory::FillIndividualTrajectory(IndividualTrajectory
     {
       G4ThreeVector localPos = point->GetPositionLocal() / CLHEP::m;
       G4ThreeVector localMom = point->GetMomentumLocal() / CLHEP::GeV;
-      itj.xyz.emplace_back(TVector3(localPos.getX(),
-                                 localPos.getY(),
-                                 localPos.getZ()));
-      itj.pxpypz.emplace_back(TVector3(localMom.getX(),
-                                    localMom.getY(),
-                                    localMom.getZ()));
+      itj.xyz.emplace_back(localPos.getX(), localPos.getY(), localPos.getZ());
+      itj.pxpypz.emplace_back(localMom.getX(), localMom.getY(), localMom.getZ());
     }
   
   if (point->extraLink)

--- a/src/BDSTrajectoryPoint.cc
+++ b/src/BDSTrajectoryPoint.cc
@@ -96,13 +96,13 @@ BDSTrajectoryPoint::BDSTrajectoryPoint(const G4Track* track,
   
   // s position for pre and post step point
   // with a track, we're at the start and have no step - use 1nm for step to aid geometrical lookup
-  BDSStep localPosition = auxNavigator->ConvertToLocal(track->GetPosition(),
-						       track->GetMomentumDirection(),
-						       1*CLHEP::nm,
-						       true);
-  prePosLocal = localPosition.PreStepPoint();
+  BDSStep localPosMom = auxNavigator->ConvertToLocal(track->GetPosition(),
+                                                     track->GetMomentum(),
+                                                     1*CLHEP::nm,
+                                                     true);
+  prePosLocal = localPosMom.PreStepPoint();
   postPosLocal = prePosLocal;
-  BDSPhysicalVolumeInfo* info = BDSPhysicalVolumeInfoRegistry::Instance()->GetInfo(localPosition.VolumeForTransform());
+  BDSPhysicalVolumeInfo* info = BDSPhysicalVolumeInfoRegistry::Instance()->GetInfo(localPosMom.VolumeForTransform());
   if (info)
     {
       G4double sCentre = info->GetSPos();
@@ -113,7 +113,7 @@ BDSTrajectoryPoint::BDSTrajectoryPoint(const G4Track* track,
     }
 
   if (storeExtrasLocal)
-    {extraLocal = new BDSTrajectoryPointLocal(prePosLocal, localPosition.PostStepPoint());}
+    {extraLocal = new BDSTrajectoryPointLocal(prePosLocal, localPosMom.PostStepPoint());} // "post step point" is momentum
   
   if (storeExtrasLink)
     {StoreExtrasLink(track);}
@@ -176,7 +176,10 @@ BDSTrajectoryPoint::BDSTrajectoryPoint(const G4Step* step,
     }
 
   if (storeExtrasLocal)
-    {extraLocal = new BDSTrajectoryPointLocal(prePosLocal, localPosition.PostStepPoint());}
+    {
+      G4ThreeVector postLocalMom = auxNavigator->ConvertAxisToLocal(postMomentum); // uses cached transform
+      extraLocal = new BDSTrajectoryPointLocal(prePosLocal, postLocalMom);
+    }
 
   G4Track* track = step->GetTrack();
   if (storeExtrasLink)

--- a/src/BDSTrajectoryPoint.cc
+++ b/src/BDSTrajectoryPoint.cc
@@ -106,8 +106,8 @@ BDSTrajectoryPoint::BDSTrajectoryPoint(const G4Track* track,
   if (info)
     {
       G4double sCentre = info->GetSPos();
-      preS             = sCentre + localPosition.PreStepPoint().z();
-      postS            = sCentre + localPosition.PostStepPoint().z();
+      preS             = sCentre + localPosMom.PreStepPoint().z();
+      postS            = preS; // no step length yet
       beamlineIndex    = info->GetBeamlineMassWorldIndex();
       beamline         = info->GetBeamlineMassWorld();
     }


### PR DESCRIPTION
Fix the local momentum (absolute) pxpypz. This was mistakenly the momentum unit vector then divided by GeV (so x 0.001). The behaviour was inconsistent between the first point (from a G4Track) and subsequent points (from G4Step).