### PR TITLE
BDSIMLink returns all particles

### DIFF
--- a/include/BDSIMLink.hh
+++ b/include/BDSIMLink.hh
@@ -66,7 +66,7 @@ public:
                  char** argv,
                  bool   usualPrintOut        = true,
                  double minimumKineticEnergy = 0,
-                 bool   protonsAndIonsOnly   = true);
+                 bool   protonsAndIonsOnly   = false);
 
   /// Construct and initialise BDSIM.
   BDSIMLink(int argc, char** argv, bool usualPrintOut=true);
@@ -147,7 +147,7 @@ public:
 private:
   /// The main function where everything is constructed.
   int Initialise(double minimumKineticEnergy = 0,
-                 bool   protonsAndIonsOnly   = true);
+                 bool   protonsAndIonsOnly   = false);
   
   bool   ignoreSIGINT;         ///< For cmake testing.
   bool   usualPrintOut;        ///< Whether to allow the usual cout output.

--- a/manual/source/interfacing.rst
+++ b/manual/source/interfacing.rst
@@ -256,12 +256,12 @@ Tracking Link Interface
 
 An interface is provided to use BDSIM components as part of another tracking library.
 
-This is in development and may not be well-finished. The main interface is the class
-:code:`BDSIMLink` that is used in place of :code:`BDSIM` (from `BDSIMClass.hh`). It is
-recommended to look through the header for the interface. It uses a simplified construction
+The main interface is the class :code:`BDSIMLink` that is used in place of
+:code:`BDSIM` (from `BDSIMClass.hh`). It is recommended to look through the
+header for the interface. It uses a simplified geometry construction
 of BDSIM with Geant4 user actions defined in classes that begin with :code:`BDSLink*`.
-
-The initial implementation is made for SixTrack and is perhaps not ideal. The output
+The interface was written (currently) only for collimators with the minimal interface
+required. The initial implementation is made for SixTrack and is perhaps not ideal. The output
 writing is broken and the CMake option :code:`USE_SIXTRACK_LINK=ON` should be used.
 
 * Only passive (i.e. with no fields) components can be used.

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -24,6 +24,10 @@ to maintain the expected high quality of the code.
 
 * For models with acceleration, the rigidity and synchronous time are now calculated
   along the beamline and pre-calculated **scaling factors are no longer needed**.
+* For any linked code, using the BDSIMLink interface, all particles are now accepted
+  into the simulation and all particles are sent back. The :code:`protonsAndIonsOnly`
+  Boolean flag still works, but by default is false. Any linked tracking code must now
+  filter the particles they can handle themselves.
 
 
 New Features

--- a/src/BDSIMLink.cc
+++ b/src/BDSIMLink.cc
@@ -72,6 +72,7 @@ along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 #include <map>
 #include <set>
 
+
 BDSIMLink::BDSIMLink(BDSBunch* bunchIn):
   ignoreSIGINT(false),
   usualPrintOut(true),

--- a/src/BDSLinkDetectorConstruction.cc
+++ b/src/BDSLinkDetectorConstruction.cc
@@ -122,7 +122,7 @@ G4VPhysicalVolume* BDSLinkDetectorConstruction::Construct()
 						   GMAD::ElementType::_ELEMENT};
       auto search = acceptedTypes.find(eType);
       if (search == acceptedTypes.end())
-	{throw BDSException(G4String("Unsupported element type for link = " + GMAD::typestr(eType)));}
+        {throw BDSException(G4String("Unsupported element type for link = " + GMAD::typestr(eType)));}
 
       // Only need first argument, the rest pertain to beamlines.
       BDSAcceleratorComponent* component = componentFactory->CreateComponent(&element,

--- a/src/BDSLinkDetectorConstruction.cc
+++ b/src/BDSLinkDetectorConstruction.cc
@@ -224,7 +224,7 @@ G4int BDSLinkDetectorConstruction::AddLinkCollimatorJaw(const std::string& colli
   G4bool isACrystal = searchC != collimatorToCrystal.end();
   if (!isACrystal && isACrystalIn)
     {throw BDSException("BDSLinkDetectorConstruction", "no matching crystal name found but it is flagged as a crystal in input");}
-  G4cout << "XYZ isACrystal " << isACrystal << G4endl;
+  //G4cout << "XYZ isACrystal " << isACrystal << G4endl;
   if (isACrystal)
     {G4cout << "crystal name " << searchC->first << " " << searchC->second << G4endl;}
 
@@ -293,7 +293,7 @@ G4int BDSLinkDetectorConstruction::AddLinkCollimatorJaw(const std::string& colli
           el.crystalAngleYAxisRight = crystalAngle + 0.5 * ci->bendingAngleYAxis;
         }
       
-      G4cout << "XYZKEY Crystal angle " << crystalAngle << G4endl;
+      G4cout << "Crystal angle " << crystalAngle << G4endl;
       G4cout << "xsizeLeft     " << el.xsizeLeft << G4endl;
       G4cout << "xsizeRight    " << el.xsizeRight << G4endl;
       G4cout << "l crystal angle " << el.crystalAngleYAxisLeft << G4endl;

--- a/src/BDSLinkEventAction.cc
+++ b/src/BDSLinkEventAction.cc
@@ -128,13 +128,13 @@ void BDSLinkEventAction::EndOfEventAction(const G4Event* evt)
     {runAction->AppendHits(currentEventIndex, primaryExternalParticleID, primaryExternalParentID, samplerLink);}
 
   output->FillEvent(nullptr,
-		    evt->GetPrimaryVertex(),
+                    evt->GetPrimaryVertex(),
                     allSamplerHits,
-		    std::vector<BDSHitsCollectionSamplerCylinder*>(),
-		    std::vector<BDSHitsCollectionSamplerSphere*>(),
+                    std::vector<BDSHitsCollectionSamplerCylinder*>(),
+                    std::vector<BDSHitsCollectionSamplerSphere*>(),
                     samplerLink,
                     nullptr,
-		    nullptr,
+                    nullptr,
                     nullptr,
                     nullptr,
                     nullptr,

--- a/src/BDSLinkPrimaryGeneratorAction.cc
+++ b/src/BDSLinkPrimaryGeneratorAction.cc
@@ -70,10 +70,10 @@ void BDSLinkPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       coords = bunch->GetNextParticleLocal();
       auto bunchSTL = dynamic_cast<BDSBunchSixTrackLink*>(bunch);
       if (bunchSTL)
-	{
-	  eventInfo->externalParticleIDofPrimary = bunchSTL->CurrentExternalParticleID();
-	  eventInfo->externalParentIDofPrimary   = bunchSTL->CurrentExternalParentID();
-	}
+        {
+          eventInfo->externalParticleIDofPrimary = bunchSTL->CurrentExternalParticleID();
+          eventInfo->externalParentIDofPrimary   = bunchSTL->CurrentExternalParentID();
+        }
     }
   catch (const BDSException& exception)
     {// we couldn't safely generate a particle -> abort

--- a/src/BDSLinkRunAction.cc
+++ b/src/BDSLinkRunAction.cc
@@ -68,18 +68,18 @@ void BDSLinkRunAction::AppendHits(G4int currentEventIndex,
       auto hit = new BDSHitSamplerLink(*(*hits)[i]);
       hit->eventID = currentEventIndex;
       if (hit->parentID == 0)
-	{// use same ones from event which are the original ones for this primary
-	  hit->externalParticleID = externalParticleID;
-	  hit->externalParentID   = externalParentID;
-	  nPrimariesToReturn++;
-	}
+        {// use same ones from event which are the original ones for this primary
+	        hit->externalParticleID = externalParticleID;
+	        hit->externalParentID   = externalParentID;
+          nPrimariesToReturn++;
+        }
       else
-	{// new secondary - give it a new index (caching that), and new parentID
-	  maximumExternalParticleID++;
-	  hit->externalParticleID = maximumExternalParticleID;
-	  hit->externalParentID   = externalParticleID;
-	  nSecondariesToReturn++;
-	}
+        {// new secondary - give it a new index (caching that), and new parentID
+          maximumExternalParticleID++;
+          hit->externalParticleID = maximumExternalParticleID;
+          hit->externalParentID   = externalParticleID;
+          nSecondariesToReturn++;
+        }
       allHits->insert(hit);
     }
 }

--- a/src/BDSLinkTrackingAction.cc
+++ b/src/BDSLinkTrackingAction.cc
@@ -35,11 +35,11 @@ along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 class G4LogicalVolume;
 
 BDSLinkTrackingAction::BDSLinkTrackingAction(G4bool batchMode,
-				     BDSLinkEventAction* eventActionIn,
-				     G4int  verboseSteppingEventStartIn,
-				     G4int  verboseSteppingEventStopIn,
-				     G4bool verboseSteppingPrimaryOnlyIn,
-				     G4int  verboseSteppingLevelIn):
+                                     BDSLinkEventAction* eventActionIn,
+                                     G4int  verboseSteppingEventStartIn,
+                                     G4int  verboseSteppingEventStopIn,
+                                     G4bool verboseSteppingPrimaryOnlyIn,
+                                     G4int  verboseSteppingLevelIn):
   interactive(!batchMode),
   eventAction(eventActionIn),
   verboseSteppingEventStart(verboseSteppingEventStartIn),
@@ -65,16 +65,16 @@ void BDSLinkTrackingAction::PreUserTrackingAction(const G4Track* track)
     {// ie secondary particle
       // only store if we want to or interactive
       if (interactive)
-	{
+        {
    
-	  auto traj = new BDSTrajectory(track,
-					interactive,
-					trajectoryStorageOptions);
-	  fpTrackingManager->SetStoreTrajectory(1);
-	  fpTrackingManager->SetTrajectory(traj);
-	}
+          auto traj = new BDSTrajectory(track,
+                                        interactive,
+                                        trajectoryStorageOptions);
+          fpTrackingManager->SetStoreTrajectory(1);
+          fpTrackingManager->SetTrajectory(traj);
+        }
       else // mark as don't store
-	{fpTrackingManager->SetStoreTrajectory(0);}
+        {fpTrackingManager->SetStoreTrajectory(0);}
     }
   else
     {// it's a primary particle
@@ -82,7 +82,7 @@ void BDSLinkTrackingAction::PreUserTrackingAction(const G4Track* track)
       // but only store the actual trajectory points if we explicitly want
       // trajectory points or we're using the visualiser.
       auto traj = new BDSTrajectoryPrimary(track,
-					   interactive, trajectoryStorageOptions, interactive);
+                                           interactive, trajectoryStorageOptions, interactive);
       fpTrackingManager->SetStoreTrajectory(1);
       fpTrackingManager->SetTrajectory(traj);
     }
@@ -98,6 +98,6 @@ void BDSLinkTrackingAction::PostUserTrackingAction(const G4Track* track)
       G4LogicalVolume* lv = track->GetVolume()->GetLogicalVolume();
       std::set<G4LogicalVolume*>* collimators = BDSAcceleratorModel::Instance()->VolumeSet("collimators");
       if (collimators->find(lv) != collimators->end())
-	{eventAction->SetPrimaryAbsorbedInCollimator(true);}
+        {eventAction->SetPrimaryAbsorbedInCollimator(true);}
     }
 }

--- a/src/BDSSDSamplerLink.cc
+++ b/src/BDSSDSamplerLink.cc
@@ -77,10 +77,6 @@ G4bool BDSSDSamplerLink::ProcessHits(G4Step* aStep, G4TouchableHistory* /*readOu
   auto pd = dp->GetParticleDefinition();
 
   // check against various filters
-  if (charge == 0) // don't return neutral particles
-    {return false;}
-  if (!pd->GetPDGStable()) // don't return unstable particles
-    {return false;}
   G4double ek = track->GetKineticEnergy();
   if (ek < minimumEK)
     {return false;}


### PR DESCRIPTION
Upon request, the BDSIM Link code now records and sends back all particles, even unstable ones. It is therefore on the other code side, to determine if the particle is suitable or not for tracking. All particles can be brought in. The main changes are in:
* `include/BDSIMLink.hh`
* `src/BDSSDSampler.cc`

The `protonsAndIonsOnly` flag in the constructor of the BDSIMLink class still works but is now set to false by default.

@stewartboogert adding you for review just now but will get Bjorn, Giacomo and Giovanni to test it before we merge.