### PR TITLE
Add print out of materials loaded from GDML.

### DIFF
--- a/src/BDSMaterials.cc
+++ b/src/BDSMaterials.cc
@@ -1263,6 +1263,13 @@ void BDSMaterials::ListMaterials() const
   G4cout << G4endl;
   G4cout << "Available NIST materials are:" << G4endl;
   G4NistManager::Instance()->ListMaterials("all");
+
+  if (!externalMaterialNames.empty())
+    {
+      G4cout << "Loaded materials from external geometry:" << G4endl;
+      for (auto &mat: externalMaterialNames)
+        {G4cout << mat << G4endl;}
+    }
   G4cout.flags(flagsCache);
 }
 

--- a/src/BDSMaterials.cc
+++ b/src/BDSMaterials.cc
@@ -1267,7 +1267,7 @@ void BDSMaterials::ListMaterials() const
   if (!externalMaterialNames.empty())
     {
       G4cout << "Loaded materials from external geometry:" << G4endl;
-      for (auto &mat: externalMaterialNames)
+      for (const auto& mat: externalMaterialNames)
         {G4cout << mat << G4endl;}
     }
   G4cout.flags(flagsCache);


### PR DESCRIPTION
 Print out happens if no material found - this is key feedback as we prepend the gdml name on load with the element name.