### PR TITLE
Fix userfile momentum

### DIFF
--- a/manual/source/model_control.rst
+++ b/manual/source/model_control.rst
@@ -1062,23 +1062,24 @@ appropriate parameters need to be defined for each individual distribution.
 
 * All parameters from `reference`_ distribution are used as centroids.
 * The default for `xDistrType`, `yDistrType` and `zDistrType` are `reference`.
+* The weight is the product of the weight supplied from each distribution (default 1).
 
 .. tabularcolumns:: |p{3cm}|p{4cm}|p{4cm}|
 
-+---------------+--------------------------------+------------------------+
-| **Variable**  | **Description**                | **Coordinates Used**   |
-+===============+================================+========================+
-| `xDistrType`  | Horizontal distribution type   | x,xp,weight            |
-+---------------+--------------------------------+------------------------+
-| `yDistrType`  | Vertical distribution type     | y,yp                   |
-+---------------+--------------------------------+------------------------+
-| `zDistrType`  | Longitudinal distribution type | z,zp,s,T,totalEnergy   |
-+---------------+--------------------------------+------------------------+
++---------------+--------------------------------+------------------------------------+
+| **Variable**  | **Description**                | **Coordinates Used**               |
++===============+================================+====================================+
+| `xDistrType`  | Horizontal distribution type   | x, xp, weight                      |
++---------------+--------------------------------+------------------------------------+
+| `yDistrType`  | Vertical distribution type     | y, yp, weight                      |
++---------------+--------------------------------+------------------------------------+
+| `zDistrType`  | Longitudinal distribution type | z, zp, s, T, totalEnergy, weight   |
++---------------+--------------------------------+------------------------------------+
  
 .. note:: It is currently not possible to use two differently specified versions of the same
- 	  distribution within the composite distribution, i.e. gaussTwiss (parameter set 1) for x
-	  and gaussTwiss (parameter set 2) for y. They will have the same settings as (for example)
-	  only one betx can be specified.
+          distribution within the composite distribution, i.e. gaussTwiss (parameter set 1) for x
+          and gaussTwiss (parameter set 2) for y. They will have the same settings as (for example)
+          only one betx can be specified.
 
 Examples: ::
 
@@ -1116,17 +1117,18 @@ one for directional, and one for energy & time.
 
 * All parameters from `reference`_ distribution are used as centroids.
 * The default for `spaceDistrType`, `directionDistrType` and `energyDistrType` are `reference`.
+* The weight is the product of the weight supplied from each distribution (default 1).
 
 .. tabularcolumns:: |p{3cm}|p{4cm}|p{4cm}|
 
 +----------------------+--------------------------------+------------------------+
 | **Variable**         | **Description**                | **Coordinates Used**   |
 +======================+================================+========================+
-| `spaceDistrType`     | Spatial distribution type      | x,y,z                  |
+| `spaceDistrType`     | Spatial distribution type      | x, y, z, weight        |
 +----------------------+--------------------------------+------------------------+
-| `directionDistrType` | Directional distribution type  | xp,yp,zp               |
+| `directionDistrType` | Directional distribution type  | xp, yp, zp, weight     |
 +----------------------+--------------------------------+------------------------+
-| `energyDistrType`    | Energy distribution type       | T,totalEnergy          |
+| `energyDistrType`    | Energy distribution type       | T, totalEnergy, weight |
 +----------------------+--------------------------------+------------------------+
 
 .. note:: It is currently not possible to use two differently specified versions of the same
@@ -1138,12 +1140,12 @@ Examples: ::
 
   beam, particle = "e-",
         kineticEnergy = 30*MeV,
-	distrType = "compositespacedirectionenergy",
-	spaceDistrType = "box",
-	directionDistrType = "sphere",
-	envelopeX = 2*cm,
-	envelopeY = 3*cm,
-	envelopeZ = 4*cm;
+        distrType = "compositespacedirectionenergy",
+        spaceDistrType = "box",
+        directionDistrType = "sphere",
+        envelopeX = 2*cm,
+        envelopeY = 3*cm,
+        envelopeZ = 4*cm;
 
 
 .. _beam-distributions-file-based:

--- a/manual/source/model_customisation.rst
+++ b/manual/source/model_customisation.rst
@@ -726,7 +726,7 @@ is automatically chosen based on the number of dimensions in the field map type.
 File Formats
 ^^^^^^^^^^^^
 
-.. note:: BDSIM field maps by default have units :math:`cm,s` and :math:`T` for magnetic
+.. note:: BDSIM field maps by default have units :math:`cm, s` and :math:`T` for magnetic
           field and :math:`V/m` for electric field.
 
 .. tabularcolumns:: |p{3cm}|p{6cm}|
@@ -734,13 +734,13 @@ File Formats
 +------------------+-----------------------------------------------------+
 | **Format**       | **Description**                                     |
 +==================+=====================================================+
-| bdsim1d          | 1D BDSIM format file  (Units :math:`cm, s, T, V\m`) |
+| bdsim1d          | 1D BDSIM format file (Units :math:`cm, s, T, V/m`)  |
 +------------------+-----------------------------------------------------+
-| bdsim2d          | 2D BDSIM format file  (Units :math:`cm, s, T, V\m`) |
+| bdsim2d          | 2D BDSIM format file (Units :math:`cm, s, T, V/m`)  |
 +------------------+-----------------------------------------------------+
-| bdsim3d          | 3D BDSIM format file  (Units :math:`cm, s, T, V\m`) |
+| bdsim3d          | 3D BDSIM format file (Units :math:`cm, s, T, V/m`)  |
 +------------------+-----------------------------------------------------+
-| bdsim4d          | 4D BDSIM format file  (Units :math:`cm, s, T, V\m`) |
+| bdsim4d          | 4D BDSIM format file (Units :math:`cm, s, T, V/m`)  |
 +------------------+-----------------------------------------------------+
 | poisson2d        | 2D Poisson Superfish SF7 file                       |
 +------------------+-----------------------------------------------------+

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -107,6 +107,9 @@ Bug Fixes
 * Fix the :code:`Event.Trajectory.pxpypz` variable in the output. It was implemented
   incorrectly in code and was not the correct data. It is now components of the momentum
   vector (absolute) in GeV/c in a frame local to that element as it should be.
+* The :code:`userfile` bunch distribution was fixed for different particle species at sub-relativisitic
+  energies. The mass of the nominal design beam particle was used instead leading to a wrong total energy
+  even for the correctly specified momentum in the distribution file.
 
 
 Output Changes

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -109,7 +109,7 @@ Bug Fixes
   vector (absolute) in GeV/c in a frame local to that element as it should be.
 * The weight of the :code:`composite` and :code:`compositesde` beam distributions is now the
   product of the x, y, z weights, whereas before it was always only the x dimension weight that was taken.
-* The :code:`userfile` bunch distribution was fixed for different particle species at sub-relativisitic
+* The :code:`userfile` bunch distribution was fixed for different particle species at sub-relativistic
   energies. The mass of the nominal design beam particle was used instead leading to a wrong total energy
   even for the correctly specified momentum in the distribution file.
 

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -107,6 +107,8 @@ Bug Fixes
 * Fix the :code:`Event.Trajectory.pxpypz` variable in the output. It was implemented
   incorrectly in code and was not the correct data. It is now components of the momentum
   vector (absolute) in GeV/c in a frame local to that element as it should be.
+* The weight of the :code:`composite` and :code:`compositesde` beam distributions is now the
+  product of the x, y, z weights, whereas before it was always only the x dimension weight that was taken.
 * The :code:`userfile` bunch distribution was fixed for different particle species at sub-relativisitic
   energies. The mass of the nominal design beam particle was used instead leading to a wrong total energy
   even for the correctly specified momentum in the distribution file.

--- a/src/BDSBunchCircle.cc
+++ b/src/BDSBunchCircle.cc
@@ -84,5 +84,5 @@ BDSParticleCoordsFull BDSBunchCircle::GetNextParticleLocal()
   G4double zp = CalculateZp(xp,yp,Zp0);
   G4double E  = E0 + envelopeE * (1-2*G4RandFlat::shoot());
   
-  return BDSParticleCoordsFull(x,y,z,xp,yp,zp,t,S0-dz,E,/*weight=*/1.0);
+  return BDSParticleCoordsFull(x,y,z,xp,yp,zp,t,S0-dz,E,/*weightIn=*/1.0);
 }

--- a/src/BDSBunchCircle.cc
+++ b/src/BDSBunchCircle.cc
@@ -84,5 +84,5 @@ BDSParticleCoordsFull BDSBunchCircle::GetNextParticleLocal()
   G4double zp = CalculateZp(xp,yp,Zp0);
   G4double E  = E0 + envelopeE * (1-2*G4RandFlat::shoot());
   
-  return BDSParticleCoordsFull(x,y,z,xp,yp,zp,t,S0-dz,E,/*weightIn=*/1.0);
+  return BDSParticleCoordsFull(x,y,z,xp,yp,zp,t,S0-dz,E,/*weight=*/1.0);
 }

--- a/src/BDSBunchComposite.cc
+++ b/src/BDSBunchComposite.cc
@@ -105,11 +105,10 @@ BDSParticleCoordsFull BDSBunchComposite::GetNextParticleLocal()
                                      yBunch->ParticleDefinitionHasBeenUpdated() ||
                                      zBunch->ParticleDefinitionHasBeenUpdated();
 
-  // TODO - the weight only comes from the x distribution here... should it be product of all?
   BDSParticleCoordsFull result(x.x, y.y, z.z,
                                x.xp, y.yp, z.zp,
                                z.T, z.s,
                                z.totalEnergy,
-                               x.weight);
+                               x.weight * y.weight * z.weight);
   return result;
 }

--- a/src/BDSBunchCompositeSDE.cc
+++ b/src/BDSBunchCompositeSDE.cc
@@ -112,6 +112,6 @@ BDSParticleCoordsFull BDSBunchCompositeSDE::GetNextParticleLocal()
                                d.xp, d.yp, d.zp,
                                e.T, s.s,
                                e.totalEnergy,
-                               e.weight);
+                               s.weight * d.weight * e.weight);
   return result;
 }

--- a/src/BDSBunchUserFile.cc
+++ b/src/BDSBunchUserFile.cc
@@ -570,6 +570,8 @@ BDSParticleCoordsFull BDSBunchUserFile<T>::GetNextParticleLocal()
         {// particle type
           ReadValue(ss, type);
           updateParticleDefinition = true; // update particle definition after finished reading line
+          delete particleDefinition;
+          particleDefinition = nullptr;
         }
       else if (it->name == "S")
         {

--- a/src/BDSBunchUserFile.cc
+++ b/src/BDSBunchUserFile.cc
@@ -609,10 +609,10 @@ BDSParticleCoordsFull BDSBunchUserFile<T>::GetNextParticleLocal()
     {
       // type is an int so FindParticle(int) is used here
       G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
-      G4ParticleDefinition* particleDef = nullptr;
+      G4ParticleDefinition* g4ParticleDef = nullptr;
       BDSIonDefinition* ionDef = nullptr;
       if (type < 1e9) // not a pdg ion
-        {particleDef = particleTable->FindParticle(type);}
+        {g4ParticleDef = particleTable->FindParticle(type);}
       else
         {
           G4IonTable* ionTable = particleTable->GetIonTable();
@@ -620,17 +620,17 @@ BDSParticleCoordsFull BDSBunchUserFile<T>::GetNextParticleLocal()
           G4double ionE;
           G4IonTable::GetNucleusByEncoding(type, ionZ, ionA, ionE, ionLevel);
           ionDef = new BDSIonDefinition(ionA, ionZ, ionZ);
-          particleDef = ionTable->GetIon(ionDef->Z(), ionDef->A(), ionDef->ExcitationEnergy());
+          g4ParticleDef = ionTable->GetIon(ionDef->Z(), ionDef->A(), ionDef->ExcitationEnergy());
         }
       
-      if (!particleDef)
+      if (!g4ParticleDef)
         {throw BDSException("BDSBunchUserFile> Particle \"" + std::to_string(type) + "\" not found");}
       // Wrap in our class that calculates momentum and kinetic energy.
       // Requires that one of E, Ek, P be non-zero (only one).
       delete particleDefinition;
       try
         {
-          particleDefinition = new BDSParticleDefinition(particleDef, E, Ek, P, ffact, ionDef);
+          particleDefinition = new BDSParticleDefinition(g4ParticleDef, E, Ek, P, ffact, ionDef);
           E = particleDefinition->TotalEnergy();
           particleDefinitionHasBeenUpdated = true;
         }

--- a/src/BDSParticleDefinition.cc
+++ b/src/BDSParticleDefinition.cc
@@ -62,9 +62,8 @@ BDSParticleDefinition::BDSParticleDefinition(G4ParticleDefinition* particleIn,
     {
       ionDefinition = new BDSIonDefinition(*ionDefinitionIn);
       if (ionDefinition->OverrideCharge()) // if override for ions
-	{charge = ionDefinition->Charge();}
+        {charge = ionDefinition->Charge();}
     }
-
   SetEnergies(totalEnergyIn, kineticEnergyIn, momentumIn);
 }
 
@@ -262,8 +261,7 @@ void BDSParticleDefinition::CalculateRigidity(const G4double& ffactIn)
 void BDSParticleDefinition::CalculateLorentzFactors()
 {
   gamma = totalEnergy / mass;
-
-  beta = std::sqrt(1 - (1./std::pow(gamma,2)) );
+  beta = std::sqrt(1 - (1./std::pow(gamma,2)));
 }
 
 void BDSParticleDefinition::ApplyChangeInKineticEnergy(G4double dEk)

--- a/src/BDSPrimaryVertexInformation.cc
+++ b/src/BDSPrimaryVertexInformation.cc
@@ -26,7 +26,7 @@ along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 #include "CLHEP/Units/PhysicalConstants.h"
 
 BDSPrimaryVertexInformation:: BDSPrimaryVertexInformation(const BDSParticleCoordsFullGlobal& primaryVertexIn,
-							  const BDSParticleDefinition*       particle):
+                                                          const BDSParticleDefinition*       particle):
   primaryVertex(primaryVertexIn),
   momentum(0),
   charge(particle->Charge()),


### PR DESCRIPTION
When a user file specifies a particle type and a momentum, the total energy of the design particle would instead be taken and the momentum in the file ignored. The momentum would then be recalculated. This has been fixed. Noticeable for sub-relativistic energies.

Few tidies along the way.