### PR TITLE
Fixed lhcleft and lhcright quadrupole fields

### DIFF
--- a/include/BDSFieldMagMultipoleOuterDual.hh
+++ b/include/BDSFieldMagMultipoleOuterDual.hh
@@ -42,6 +42,7 @@ public:
 				G4double           brho,
 				G4double           separation,
 				G4bool             secondFieldOnLeft = true,
+                G4bool             secondFieldInverted = true,
 				G4double           arbitraryScaling  = 1.0);
   
   virtual ~BDSFieldMagMultipoleOuterDual();
@@ -53,6 +54,7 @@ public:
 private:
   BDSFieldMagMultipoleOuter* fieldBase;
   G4ThreeVector offset;
+  G4bool invertSecondField;
 };
 
 #endif

--- a/src/BDSFieldFactory.cc
+++ b/src/BDSFieldFactory.cc
@@ -778,7 +778,7 @@ BDSFieldMag* BDSFieldFactory::CreateFieldMagRaw(const BDSFieldInfo&      info,
         else
           {
             field = new BDSFieldMagMultipoleOuterDual(1, poleTipRadius, innerField, positiveField2, brho, dx,
-                                                      info.SecondFieldOnLeft(), GetOuterScaling(strength));
+                                                      info.SecondFieldOnLeft(), true, GetOuterScaling(strength));
           }
         delete innerField; // no longer required
         break;
@@ -796,7 +796,7 @@ BDSFieldMag* BDSFieldFactory::CreateFieldMagRaw(const BDSFieldInfo&      info,
         else
           {
             field = new BDSFieldMagMultipoleOuterDual(2, poleTipRadius, innerField, positiveField, brho, dx,
-                                                      info.SecondFieldOnLeft(), GetOuterScaling(strength));
+                                                      info.SecondFieldOnLeft(), false, GetOuterScaling(strength));
           }
         delete innerField; // no longer required
         break;
@@ -814,7 +814,7 @@ BDSFieldMag* BDSFieldFactory::CreateFieldMagRaw(const BDSFieldInfo&      info,
         else
           {
             field = new BDSFieldMagMultipoleOuterDual(3, poleTipRadius, innerField, positiveField, dx, brho,
-                                                      info.SecondFieldOnLeft(), GetOuterScaling(strength));
+                                                      info.SecondFieldOnLeft(), true, GetOuterScaling(strength));
           }
         delete innerField; // no longer required
         break;

--- a/src/BDSFieldMagMultipoleOuterDual.cc
+++ b/src/BDSFieldMagMultipoleOuterDual.cc
@@ -28,6 +28,7 @@ BDSFieldMagMultipoleOuterDual::BDSFieldMagMultipoleOuterDual(G4int              
 							     G4double           brho,
 							     G4double           separation,
 							     G4bool             secondFieldOnLeft,
+                                 G4bool             secondFieldInverted,
 							     G4double           arbitraryScaling):
   fieldBase(nullptr)
 {
@@ -35,6 +36,7 @@ BDSFieldMagMultipoleOuterDual::BDSFieldMagMultipoleOuterDual(G4int              
 					    kPositive, brho, arbitraryScaling);
   G4double offsetX = secondFieldOnLeft ? -separation : separation;
   offset = G4ThreeVector(offsetX,0,0);
+  invertSecondField = secondFieldInverted;
 }
 
 BDSFieldMagMultipoleOuterDual::~BDSFieldMagMultipoleOuterDual()
@@ -48,7 +50,10 @@ G4ThreeVector BDSFieldMagMultipoleOuterDual::GetField(const G4ThreeVector& posit
   G4ThreeVector aSide      = fieldBase->GetField(position, t);
   G4ThreeVector shiftedPos = position + offset;
   G4ThreeVector bSide      = fieldBase->GetField(shiftedPos,t);
-  bSide *= -1.0; // opposite to whatever 'a' side is
+  if (invertSecondField)
+  {
+      bSide *= -1.0; // opposite to whatever 'a' side
+  }
   G4ThreeVector result = aSide + bSide;
   return result;
 }

--- a/src/BDSMagnet.cc
+++ b/src/BDSMagnet.cc
@@ -262,9 +262,14 @@ void BDSMagnet::BuildOuterField()
               BDSFieldInfo* secondBPField = new BDSFieldInfo(*vacuumFieldInfo);
               G4double sign = mgt == BDSMagnetGeometryType::lhcleft ? 1.0 : -1.0;
               secondBPField->Translate(G4ThreeVector(sign * BDSMagnetOuterFactoryLHC::beamSeparation, 0, 0));
-              (*(secondBPField->MagnetStrength()))["field"] *= -1; // flip the sign
-              if (BDS::IsFinite((*(secondBPField->MagnetStrength()))["k1"]))
+
+              if (magnetType != BDSMagnetType::quadrupole)
+              {
+                (*(secondBPField->MagnetStrength()))["field"] *= -1; // flip the sign
+                if (BDS::IsFinite((*(secondBPField->MagnetStrength()))["k1"]))
                 {(*(secondBPField->MagnetStrength()))["k1"] *= -1;}
+              }
+
               secondBPField->SetIntegratorType(BDSIntegratorType::g4classicalrk4);
               BDSFieldBuilder::Instance()->RegisterFieldForConstruction(secondBPField,
                                                                         daughters[0]->GetContainerLogicalVolume(),

--- a/test/BDSFieldTester.cc
+++ b/test/BDSFieldTester.cc
@@ -207,7 +207,7 @@ int main(int /*argc*/, char** /*argv*/)
   // outer lhc dipole
   innerField = new BDSFieldMagDipole(st);
   positiveField = (*st)["field"] < 0; // note convention for dipoles here
-  field = new BDSFieldMagMultipoleOuterDual(1, poleTipRadius, innerField, positiveField, lhcDX, true);
+  field = new BDSFieldMagMultipoleOuterDual(1, poleTipRadius, innerField, positiveField, lhcDX, true, true, true);
   delete innerField;
   fields.push_back(field);
   names.emplace_back("multipoleouterdipolelhc");
@@ -215,7 +215,7 @@ int main(int /*argc*/, char** /*argv*/)
   // outer lhc quadrupole
   innerField = new BDSFieldMagQuadrupole(st, brho);
   positiveField = (*st)["k1"] > 0;
-  field = new BDSFieldMagMultipoleOuterDual(2, poleTipRadius, innerField, positiveField, lhcDX, true);
+  field = new BDSFieldMagMultipoleOuterDual(2, poleTipRadius, innerField, positiveField, lhcDX, true, true, false);
   delete innerField;
   fields.push_back(field);
   names.emplace_back("multipoleouterquadrupolelhc");
@@ -223,7 +223,7 @@ int main(int /*argc*/, char** /*argv*/)
   // outer lhc sextupole
   innerField = new BDSFieldMagSextupole(st, brho);
   positiveField = (*st)["k2"] > 0;
-  field = new BDSFieldMagMultipoleOuterDual(3, poleTipRadius, innerField, positiveField, lhcDX, true);
+  field = new BDSFieldMagMultipoleOuterDual(3, poleTipRadius, innerField, positiveField, lhcDX, true, true, true);
   delete innerField;
   fields.push_back(field);
   names.emplace_back("multipoleoutersextupolelhc");


### PR DESCRIPTION
The quadrupole field in the secondary aperture in lhcleft and lhcright magnets was incorrectly flipped.
Added quadrupoles as an exception to flipping the sign of both the outer and vacuum field.