### PR TITLE
ci/cd: move to macos14, 15, 15-intel

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
-        os: [macOS-13, macOS-14]
+        os: [macOS-14, macOS-15, macOS-15-intel]
 #        geant4-version: ["v10.7.4","v11.1.3"]
 #        os: [macOS-13]
 
@@ -94,18 +94,19 @@ jobs:
         shell: bash      
         run: |
           # Switch bison depending on macOS
-          if [[ "${{ matrix.os }}" == "macOS-13" ]]; then
-            echo "BISON_PATH=/usr/local/opt/bison/bin/bison" >> $GITHUB_ENV
-          elif [[ "${{ matrix.os }}" == "macOS-14" ]]; then
+          if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
             echo "BISON_PATH=/opt/homebrew/opt/bison/bin/bison" >> $GITHUB_ENV
+          elif [[ "${{ matrix.os }}" == "macOS-15" ]]; then
+            echo "BISON_PATH=/opt/homebrew/opt/bison/bin/bison" >> $GITHUB_ENV
+          elif [[ "${{ matrix.os }}" == "macOS-15-intel" ]]; then
+            echo "BISON_PATH=/usr/local/opt/bison/bin/bison" >> $GITHUB_ENV
           fi
-
 
       - name: Get Geant4
         shell: bash
         run: |
           # download geant4 build
-          wget -q https://github.com/bdsim-collaboration/mac_geant4/releases/download/v0.0.25/geant4-${{ matrix.os}}-${{ matrix.geant4-version }}.tgz
+          wget -q https://github.com/bdsim-collaboration/mac_geant4/releases/download/v0.0.26/geant4-${{ matrix.os}}-${{ matrix.geant4-version }}.tgz
           # unpack geant4
           tar zxf geant4-${{ matrix.os }}-${{ matrix.geant4-version }}.tgz -C /tmp/
 
@@ -120,10 +121,12 @@ jobs:
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
 
           # Set up root, geant4 and bdsim
-          if [[ "${{ matrix.os }}" == "macOS-13" ]]; then
-            source /usr/local/bin/thisroot.sh
-          elif [[ "${{ matrix.os }}" == "macOS-14" ]]; then
+          if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
             source /opt/homebrew/bin/thisroot.sh  
+          elif [[ "${{ matrix.so }}" == "macOS-15" ]]; then
+            source /opt/homebrew/bin/thisroot.sh	  
+          elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
+            source /usr/local/homebrew/bin/thisroot.sh	  
           fi 
           
           # build

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -78,7 +78,7 @@ jobs:
 #        geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
 #        os: [macOS-14, macOS-15, macOS-15-intel]
         geant4-version: ["v11.3.2"]
-        os: [macOS-15]
+        os: [macOS-15, macOS-15-intel]
 
     steps:
       - uses: actions/checkout@v4
@@ -124,9 +124,11 @@ jobs:
           if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
             source /opt/homebrew/bin/thisroot.sh  
           elif [[ "${{ matrix.so }}" == "macOS-15" ]]; then
-            source /opt/homebrew/bin/thisroot.sh	  
+            source /opt/homebrew/bin/thisroot.sh
+            export ROOTSYS=/opt/homebrew/
           elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
-            source /usr/local/homebrew/bin/thisroot.sh	  
+            source /usr/homebrew/bin/thisroot.sh
+            export ROOTSYS=/usr/homebrew/
           fi 
           
           # build

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -140,6 +140,8 @@ jobs:
         shell: bash
         run: |
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
+          source /tmp/bdsim-install/bin/bdsim.sh
+
           # Set up root
           if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
             source /opt/homebrew/bin/thisroot.sh  
@@ -148,7 +150,6 @@ jobs:
           elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
             source /usr/local/homebrew/bin/thisroot.sh	  
           fi 
-          source /tmp/bdsim-install/bin/bdsim.sh
 
           # geant4 contains absolute paths
           if [[ "${{ matrix.geant4-version }}" == "v10.7.4" ]]; then

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: [ubuntu20-g4.10.7, ubuntu20-g4.11.0, ubuntu20-g4.11.1, ubuntu20-g4.11.2, ubuntu20-g4.11.3,
-                    ubuntu22-g4.10.7, ubuntu22-g4.11.0, ubuntu22-g4.11.1, ubuntu22-g4.11.2, ubuntu22-g4.11.3,
-                    ubuntu24-g4.10.7, ubuntu24-g4.11.0, ubuntu24-g4.11.1, ubuntu24-g4.11.2, ubuntu24-g4.11.3,
-                    centos8-g4.10.7, centos8-g4.11.0, centos8-g4.11.1, centos8-g4.11.2, centos8-g4.11.3,
-                    alma9-g4.10.7, alma9-g4.11.0, alma9-g4.11.1, alma9-g4.11.2, alma9-g4.11.3]
-#        container: [ubuntu20-g4.11.0]
+#        container: [ubuntu20-g4.10.7, ubuntu20-g4.11.0, ubuntu20-g4.11.1, ubuntu20-g4.11.2, ubuntu20-g4.11.3,
+#                    ubuntu22-g4.10.7, ubuntu22-g4.11.0, ubuntu22-g4.11.1, ubuntu22-g4.11.2, ubuntu22-g4.11.3,
+#                    ubuntu24-g4.10.7, ubuntu24-g4.11.0, ubuntu24-g4.11.1, ubuntu24-g4.11.2, ubuntu24-g4.11.3,
+#                    centos8-g4.10.7, centos8-g4.11.0, centos8-g4.11.1, centos8-g4.11.2, centos8-g4.11.3,
+#                    alma9-g4.10.7, alma9-g4.11.0, alma9-g4.11.1, alma9-g4.11.2, alma9-g4.11.3]
+        container: [ubuntu20-g4.11.0]
     steps:
       - name: Checkout bdsim
         uses: actions/checkout@v4
@@ -75,10 +75,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
-        os: [macOS-14, macOS-15, macOS-15-intel]
-#        geant4-version: ["v10.7.4","v11.1.3"]
-#        os: [macOS-13]
+#        geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
+#        os: [macOS-14, macOS-15, macOS-15-intel]
+        geant4-version: ["v11.3.2"]
+        os: [macOS-15]
 
     steps:
       - uses: actions/checkout@v4
@@ -140,6 +140,14 @@ jobs:
         shell: bash
         run: |
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
+          # Set up root
+          if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
+            source /opt/homebrew/bin/thisroot.sh  
+          elif [[ "${{ matrix.so }}" == "macOS-15" ]]; then
+            source /opt/homebrew/bin/thisroot.sh	  
+          elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
+            source /usr/local/homebrew/bin/thisroot.sh	  
+          fi 
           source /tmp/bdsim-install/bin/bdsim.sh
 
           # geant4 contains absolute paths

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -142,15 +142,6 @@ jobs:
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
           source /tmp/bdsim-install/bin/bdsim.sh
 
-          # Set up root
-          if [[ "${{ matrix.os }}" == "macOS-14" ]]; then
-            source /opt/homebrew/bin/thisroot.sh  
-          elif [[ "${{ matrix.so }}" == "macOS-15" ]]; then
-            source /opt/homebrew/bin/thisroot.sh	  
-          elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
-            source /usr/local/homebrew/bin/thisroot.sh	  
-          fi 
-
           # geant4 contains absolute paths
           if [[ "${{ matrix.geant4-version }}" == "v10.7.4" ]]; then
             export G4NEUTRONHPDATA="/tmp/geant4-${{ matrix.geant4-version }}/share/Geant4-10.7.4/data/G4NDL4.6"

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        container: [ubuntu20-g4.10.7, ubuntu20-g4.11.0, ubuntu20-g4.11.1, ubuntu20-g4.11.2, ubuntu20-g4.11.3,
-#                    ubuntu22-g4.10.7, ubuntu22-g4.11.0, ubuntu22-g4.11.1, ubuntu22-g4.11.2, ubuntu22-g4.11.3,
-#                    ubuntu24-g4.10.7, ubuntu24-g4.11.0, ubuntu24-g4.11.1, ubuntu24-g4.11.2, ubuntu24-g4.11.3,
-#                    centos8-g4.10.7, centos8-g4.11.0, centos8-g4.11.1, centos8-g4.11.2, centos8-g4.11.3,
-#                    alma9-g4.10.7, alma9-g4.11.0, alma9-g4.11.1, alma9-g4.11.2, alma9-g4.11.3]
-        container: [ubuntu20-g4.11.0]
+        container: [ubuntu20-g4.10.7, ubuntu20-g4.11.0, ubuntu20-g4.11.1, ubuntu20-g4.11.2, ubuntu20-g4.11.3,
+                    ubuntu22-g4.10.7, ubuntu22-g4.11.0, ubuntu22-g4.11.1, ubuntu22-g4.11.2, ubuntu22-g4.11.3,
+                    ubuntu24-g4.10.7, ubuntu24-g4.11.0, ubuntu24-g4.11.1, ubuntu24-g4.11.2, ubuntu24-g4.11.3,
+                    centos8-g4.10.7, centos8-g4.11.0, centos8-g4.11.1, centos8-g4.11.2, centos8-g4.11.3,
+                    alma9-g4.10.7, alma9-g4.11.0, alma9-g4.11.1, alma9-g4.11.2, alma9-g4.11.3]
+#        container: [ubuntu20-g4.11.0]
     steps:
       - name: Checkout bdsim
         uses: actions/checkout@v4
@@ -75,10 +75,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
-#        os: [macOS-14, macOS-15, macOS-15-intel]
-        geant4-version: ["v11.3.2"]
-        os: [macOS-15, macOS-15-intel]
+        geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
+        os: [macOS-14, macOS-15, macOS-15-intel]
+#        geant4-version: ["v11.3.2"]
+#        os: [macOS-15, macOS-15-intel]
 
     steps:
       - uses: actions/checkout@v4
@@ -125,10 +125,8 @@ jobs:
             source /opt/homebrew/bin/thisroot.sh  
           elif [[ "${{ matrix.so }}" == "macOS-15" ]]; then
             source /opt/homebrew/bin/thisroot.sh
-            export ROOTSYS=/opt/homebrew/
           elif [[ "${{ matrix.so }}" == "macOS-15-intel" ]]; then
             source /usr/homebrew/bin/thisroot.sh
-            export ROOTSYS=/usr/homebrew/
           fi 
           
           # build
@@ -144,7 +142,6 @@ jobs:
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
           source /tmp/bdsim-install/bin/bdsim.sh
 
-          echo $(which root)
           # geant4 contains absolute paths
           if [[ "${{ matrix.geant4-version }}" == "v10.7.4" ]]; then
             export G4NEUTRONHPDATA="/tmp/geant4-${{ matrix.geant4-version }}/share/Geant4-10.7.4/data/G4NDL4.6"

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -142,6 +142,7 @@ jobs:
           source /tmp/geant4-${{ matrix.geant4-version }}/bin/geant4.sh
           source /tmp/bdsim-install/bin/bdsim.sh
 
+          echo $(which root)
           # geant4 contains absolute paths
           if [[ "${{ matrix.geant4-version }}" == "v10.7.4" ]]; then
             export G4NEUTRONHPDATA="/tmp/geant4-${{ matrix.geant4-version }}/share/Geant4-10.7.4/data/G4NDL4.6"

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -36,9 +36,6 @@ else()
 
   message(STATUS "Using root-config: ${ROOT_CONFIG_EXECUTABLE}")
 
-  set(ROOT_EXECUTABLE ${ROOTSYS}/bin/root)
-  message(STATUS "Using root-executable: ${ROOT_EXECUTABLE}")
-
   execute_process(
     COMMAND ${ROOT_CONFIG_EXECUTABLE} --prefix 
     OUTPUT_VARIABLE ROOTSYS 
@@ -63,6 +60,9 @@ else()
     COMMAND ${ROOT_CONFIG_EXECUTABLE} --evelibs
     OUTPUT_VARIABLE ROOT_EVELIBRARIES
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  set(ROOT_EXECUTABLE ${ROOTSYS}/bin/root)
+  message(STATUS "Using root-executable: ${ROOT_EXECUTABLE}")
 
   # Hack to remove c++11 lib in favour of the one provided already
   if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -37,7 +37,6 @@ else()
   message(STATUS "Using root-config: ${ROOT_CONFIG_EXECUTABLE}")
 
   set(ROOT_EXECUTABLE ${ROOTSYS}/bin/root)
-
   message(STATUS "Using root-executable: ${ROOT_EXECUTABLE}")
 
   execute_process(

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -38,6 +38,8 @@ else()
 
   set(ROOT_EXECUTABLE ${ROOTSYS}/bin/root)
 
+  message(STATUS "Using root-executable: ${ROOT_EXECUTABLE}")
+
   execute_process(
     COMMAND ${ROOT_CONFIG_EXECUTABLE} --prefix 
     OUTPUT_VARIABLE ROOTSYS 


### PR DESCRIPTION
Moved runners to macos-14, macos-15 and macos-15-intel. Mainly because macos-13 homebrew is depreciated and some brew recipes fail building from source on macos-13 

Root executable discovery needed to be moved in the CMake for the testing