### PR TITLE
File based recreation when looping a file.

### DIFF
--- a/include/BDSPrimaryGeneratorFile.hh
+++ b/include/BDSPrimaryGeneratorFile.hh
@@ -79,6 +79,10 @@ public:
   /// Return whether at least 1 event has passed a filter in the file. If we have no
   /// events in the file that pass then we will loop infinitely to find one.
   G4bool OKToLoopFile() const;
+
+  /// Mark internally that we are recreating and that therefore do not check if any
+  /// particles have been successfully loaded before looping.
+  void SetRecreationOn() {recreate = true;}
   
   /// Accessor.
   G4long NEventsReadThatPassedFilters() const {return nEventsReadThatPassedFilters;}
@@ -100,6 +104,7 @@ protected:
 
   G4bool loopFile;
   BDSBunchEventGenerator* bunch;
+  G4bool recreate;
   G4bool endOfFileReached;
   G4bool vertexGeneratedSuccessfully;
   G4long currentFileEventIndex;

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -134,6 +134,9 @@ Bug Fixes
 * The :code:`userfile` bunch distribution was fixed for different particle species at sub-relativistic
   energies. The mass of the nominal design beam particle was used instead leading to a wrong total energy
   even for the correctly specified momentum in the distribution file.
+* Fix loading of a BDSIM output sampler bunch distribution or a HEPMC file loading when
+  recreating a file and the chosen event offset requires looping the file. It would loop
+  and advance to the same place proplery.
 
 
 Output Changes

--- a/src/BDSPrimaryGeneratorFile.cc
+++ b/src/BDSPrimaryGeneratorFile.cc
@@ -48,6 +48,7 @@ BDSPrimaryGeneratorFile::BDSPrimaryGeneratorFile(G4bool loopFileIn,
                                                  BDSBunchEventGenerator* bunchIn):
   loopFile(loopFileIn),
   bunch(bunchIn),
+  recreate(false),
   endOfFileReached(false),
   vertexGeneratedSuccessfully(false),
   currentFileEventIndex(0),
@@ -86,7 +87,7 @@ G4long BDSPrimaryGeneratorFile::NEventsLeftInFile() const
 
 G4bool BDSPrimaryGeneratorFile::OKToLoopFile() const
 {
-  return nEventsReadThatPassedFilters > 0;
+  return nEventsReadThatPassedFilters > 0 || recreate;
 }
 
 BDSPrimaryGeneratorFile* BDSPrimaryGeneratorFile::ConstructGenerator(const GMAD::Beam& beam,
@@ -137,7 +138,10 @@ BDSPrimaryGeneratorFile* BDSPrimaryGeneratorFile::ConstructGenerator(const GMAD:
       
       // common bits
       if (recreate)
-        {generatorFromFile->RecreateAdvanceToEvent(eventOffset);}
+        {
+          generatorFromFile->RecreateAdvanceToEvent(eventOffset);
+          generatorFromFile->SetRecreationOn();
+        }
       if (beam.distrFileMatchLength)
         {
           G4int nEventsPerLoop = (G4int)generatorFromFile->NEventsLeftInFile();

--- a/src/BDSPrimaryGeneratorFileHEPMC.cc
+++ b/src/BDSPrimaryGeneratorFileHEPMC.cc
@@ -234,7 +234,7 @@ void BDSPrimaryGeneratorFileHEPMC::SkipEvents(G4int nEventsToSkip)
       msg += ") in this file.";
       throw BDSException("BDSBunchUserFile::RecreateAdvanceToEvent>", msg);
     }
-  G4long nToSkipSinglePass = nAvailable % nEventsToSkip;
+  G4long nToSkipSinglePass = nEventsToSkip % nEventsInFile;
   for (G4int i = 0; i < nToSkipSinglePass; i++)
     {ReadSingleEvent();}
 }

--- a/src/BDSPrimaryGeneratorFileSampler.cc
+++ b/src/BDSPrimaryGeneratorFileSampler.cc
@@ -301,6 +301,6 @@ void BDSPrimaryGeneratorFileSampler::SkipEvents(G4long nEventsToSkip)
       msg += ") in this file.";
       throw BDSException("BDSBunchUserFile::RecreateAdvanceToEvent>", msg);
     }
-  G4long nToSkipSinglePass = nAvailable % nEventsToSkip;
+  G4long nToSkipSinglePass = nEventsToSkip % nEventsInFile;
   currentFileEventIndex = nToSkipSinglePass;
 }


### PR DESCRIPTION
In the case of recreating a simulation, and using (originally) a BDSIM output file sampler or HEPMC file as input distribution, the recreation event offset would not load the right point the in file. If say, the event you wanted to recreate was after N loops of the file it should be advanced to `event_index % n_events_in_file` whereas previously this was wrong.