### PR TITLE
pybdind11:: fix deprecation warning

### DIFF
--- a/python/arrayPybind.cc
+++ b/python/arrayPybind.cc
@@ -41,7 +41,7 @@ PYBIND11_MODULE(array, m) {
 
       bool homogeneous = true;
       for (py::handle item : l) {
-        if (!item.get_type().is(first_type)) {
+        if (!py::type::of(item).is(first_type)) {
           homogeneous = false;
           break;
         }

--- a/python/arrayPybind.cc
+++ b/python/arrayPybind.cc
@@ -37,7 +37,7 @@ PYBIND11_MODULE(array, m) {
         return a;
       }
 
-      auto first_type = l[0].get_type();
+      auto first_type = py::type::of(l[0]);
 
       bool homogeneous = true;
       for (py::handle item : l) {


### PR DESCRIPTION
Fix for #123 

@lnevay you need to pull this branch on your local computer and compile as the warning is new for MacOS26 Tahoe. 