### PR TITLE
Fix issue 85 - revise trajectory depth map build up

### DIFF
--- a/manual/source/model_control.rst
+++ b/manual/source/model_control.rst
@@ -1965,7 +1965,7 @@ Examples: ::
 +------------------------------+------------------------------------------------------------------------+
 | cherenkov                    | Provides Cherenkov radiation for all charged particles. Issued by the  |
 |                              | BDSIM physics builder `BDSPhysicsCherenkov` that provides the process  |
-|                              | `G4CherenkovProcess`.                                                  |
+|                              | `G4CherenkovProcess` only.                                             |
 +------------------------------+------------------------------------------------------------------------+
 | decay                        | Provides radioactive decay processes using `G4DecayPhysics`. Crucial   |
 |                              | for pion decay for example.                                            |

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -156,6 +156,12 @@ Bug Fixes
 * Document the options :code:`maximumPhotonsPerStep` and :code:`maximumBetaChangePerStep` as well
   as fix their number type internally.
 * Fix a crash when using :code:`jcoltip` with collimator-specific output options.
+* Fix modular physics list that would accept optical physics and cherenkov physics at the same
+  time which would try to double-register cherenkov physics (Geant4 would refuse).
+* Fix an uncaught exception when trajectory storage was used and optical physics or cherenkov
+  physics was used that would break the assumed ordering of trajectories in Geant4.
+* Fix the cherenkov parameters :code:`maximumPhotonsPerStep` and :code:`maximumBetaChangePerStep` when
+  used with optical physics, which would previously have no effect.
 
 
 Output Changes

--- a/src/BDSEventAction.cc
+++ b/src/BDSEventAction.cc
@@ -478,7 +478,12 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
 
   if (storeTrajectory && trajCont)
     {
+      // cast all trajectories to BDSTrajectory once
       TrajectoryVector* trajVec = trajCont->GetVector();
+      std::vector<BDSTrajectory*> trajVecBDS;
+      trajVecBDS.reserve(trajVec->size());
+      std::transform(trajVec->begin(), trajVec->end(), std::back_inserter(trajVecBDS),
+                     [](G4VTrajectory* a) { return static_cast<BDSTrajectory*>(a); });
       
       // build trackID map, depth map
       std::map<int, BDSTrajectory*> trackIDMap;
@@ -512,12 +517,10 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
       // keep tallies of how many will and won't be stored
       G4int nYes = 0;
       G4int nNo  = 0;
-      for (auto iT1 : *trajVec)
+      for (auto* tr : trajVecBDS)
         {
           std::bitset<BDS::NTrajectoryFilters> filters;
-          
-          BDSTrajectory* traj = static_cast<BDSTrajectory*>(iT1);
-          G4int parentID = traj->GetParentID();
+          G4int parentID = tr->GetParentID();
           
           // always store primaries
           if (parentID == 0)
@@ -529,15 +532,14 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
             }
           
           // check on energy (if energy threshold is not negative)
-          if (trajectoryEnergyThreshold >= 0 &&
-              traj->GetInitialKineticEnergy() > trajectoryEnergyThreshold)
+          if (trajectoryEnergyThreshold >= 0 && tr->GetInitialKineticEnergy() > trajectoryEnergyThreshold)
             {filters[BDSTrajectoryFilter::energyThreshold] = true;}
           
           // check on particle if not empty string
           if (!trajParticleNameToStore.empty() || !trajParticleIDToStore.empty())
             {
-              G4String particleName  = traj->GetParticleName();
-              G4int particleID       = traj->GetPDGEncoding();
+              G4String particleName  = tr->GetParticleName();
+              G4int particleID       = tr->GetPDGEncoding();
               G4String particleIDStr = G4String(std::to_string(particleID));
               std::size_t found1     = trajParticleNameToStore.find(particleName);
               bool        found2     = (std::find(trajParticleIDIntToStore.begin(), trajParticleIDIntToStore.end(), particleID)
@@ -547,12 +549,12 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
             }
           
           // check on trajectory tree depth (trajDepth = 0 means only primaries)
-          if (depthMap[traj] <= trajDepth || storeTrajectoryAll) // all means to infinite trajDepth really
+          if (depthMap[tr] <= trajDepth || storeTrajectoryAll) // all means to infinite trajDepth really
             {filters[BDSTrajectoryFilter::depth] = true;}
           
           // check on coordinates (and TODO momentum)
           // clear out trajectories that don't reach point TrajCutGTZ or greater than TrajCutLTR
-          BDSTrajectoryPoint* trajEndPoint = static_cast<BDSTrajectoryPoint*>(traj->GetPoint(traj->GetPointEntries() - 1));
+          BDSTrajectoryPoint* trajEndPoint = static_cast<BDSTrajectoryPoint*>(tr->GetPoint(tr->GetPointEntries() - 1));
           
           // end point greater than some Z
           if (trajEndPoint->GetPosition().z() > trajectoryCutZ)
@@ -563,8 +565,8 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
             {filters[BDSTrajectoryFilter::maximumR] = true;}
           
           filters.any() ? nYes++ : nNo++;
-          interestingTraj.insert(std::pair<BDSTrajectory*, bool>(traj, filters.any()));
-          trajectoryFilters.insert(std::pair<BDSTrajectory*, std::bitset<BDS::NTrajectoryFilters> >(traj, filters)); 
+          interestingTraj.insert(std::pair<BDSTrajectory*, bool>(tr, filters.any()));
+          trajectoryFilters.insert(std::pair<BDSTrajectory*, std::bitset<BDS::NTrajectoryFilters> >(tr, filters));
         }
       
       // loop over energy hits to connect trajectories
@@ -679,6 +681,7 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
       // Output interesting trajectories
       if (verbose)
         {G4cout << std::left << std::setw(nChar) << "Trajectories for storage: " << nYes << " out of " << nYes + nNo << G4endl;}
+      trajVecBDS.clear(); // does not delete the pointers as just casts
     }
   G4cout.flags(flagsCache);
   return new BDSTrajectoriesToStore(interestingTraj, trajectoryFilters);

--- a/src/BDSEventAction.cc
+++ b/src/BDSEventAction.cc
@@ -582,7 +582,7 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
                   double dS = hit->GetSHit();
                   for (const auto& v : trajSRangeToStore)
                     {           
-                      if ( dS >= v.first && dS <= v.second) 
+                      if (dS >= v.first && dS <= v.second)
                         {
                           BDSTrajectory* trajToStore = trackIDMap[hit->GetTrackID()];
                           if (!interestingTraj[trajToStore])
@@ -607,7 +607,7 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
                   double dS = hit->GetSHit();
                   for (const auto& v : trajSRangeToStore)
                     {           
-                      if ( dS >= v.first && dS <= v.second) 
+                      if (dS >= v.first && dS <= v.second)
                         {
                           BDSTrajectory* trajToStore = trackIDMap[hit->GetTrackID()];
                           if (!interestingTraj[trajToStore])

--- a/src/BDSEventAction.cc
+++ b/src/BDSEventAction.cc
@@ -485,32 +485,31 @@ BDSTrajectoriesToStore* BDSEventAction::IdentifyTrajectoriesForStorage(const G4E
       std::transform(trajVec->begin(), trajVec->end(), std::back_inserter(trajVecBDS),
                      [](G4VTrajectory* a) { return static_cast<BDSTrajectory*>(a); });
       
-      // build trackID map, depth map
+      // build trackID map
       std::map<int, BDSTrajectory*> trackIDMap;
+      for (auto* tr : trajVecBDS)
+        {trackIDMap[tr->GetTrackID()] = tr;}
+      trackIDMap[0] = nullptr; // primary has no parent
+
+#ifdef BDSDEBUG
+      for (auto* tr : trajVecBDS)
+        {G4cout << tr->GetTrackID() << " " << tr->GetParentID() << G4endl;}
+#endif
+
+      // build depth map
       std::map<BDSTrajectory*, int> depthMap;
-      for (auto iT1 : *trajVec)
+      for (auto* tr : trajVecBDS)
         {
-          BDSTrajectory* traj = static_cast<BDSTrajectory*>(iT1);
-          
-          // fill track ID map
-          trackIDMap[traj->GetTrackID()] = traj;
-          
-          // fill depth map
-          G4int depth = traj->GetParentID() == 0 ? 0 : depthMap.at(trackIDMap.at(traj->GetParentID())) + 1;
-          traj->SetDepth(depth);
-          if (traj->GetParentID() == 0) 
-            {depthMap[traj] = 0;}
-          else
-            {depthMap[traj] = depthMap.at(trackIDMap.at(traj->GetParentID())) + 1;}
-        }
-      
-      // fill parent pointer - this can only be done once the map in the previous loop has been made
-      for (auto iT1 : *trajVec) 
-        {
-          BDSTrajectory* traj = static_cast<BDSTrajectory*>(iT1);
-          // the parent ID may be 0 and therefore it may not be in the map but the [] operator
-          // will default-construct it giving therefore a nullptr
-          traj->SetParent(trackIDMap[iT1->GetParentID()]);
+          G4int depth = 0;
+          BDSTrajectory* ct = tr;
+          // recurse up to a primary trackID and count the number of parents
+          while (ct->GetParentID() != 0)
+            {
+              ct = trackIDMap[ct->GetParentID()];
+              depth++;
+            }
+          depthMap[tr] = depth;
+          tr->SetParent(trackIDMap[tr->GetParentID()]);
         }
       
       // loop over trajectories and determine if it should be stored

--- a/src/BDSModularPhysicsList.cc
+++ b/src/BDSModularPhysicsList.cc
@@ -307,8 +307,7 @@ BDSModularPhysicsList::BDSModularPhysicsList(const G4String& physicsList):
   for (const auto& kv : physicsConstructors)
     {incompatible.insert(std::make_pair(kv.first, std::vector<G4String>()));}
   incompatible["annihi_to_mumu"] = {"em_extra"};
-  incompatible["muon"] = {"em_extra"};
-  incompatible["muon_inelastic"] = {"em_extra", "muon"};
+  incompatible["cherenkov"] = {"optical"};
   incompatible["dna"]    = {"dna_1", "dna_2", "dna_3", "dna_4", "dna_5", "dna_6", "dna_7", "dna_chemistry", "dna_chemistry_1", "dna_chemistry_2", "dna_chemistry_3"};
   incompatible["dna_1"]  = {"dna",   "dna_2", "dna_3", "dna_4", "dna_5", "dna_6", "dna_7", "dna_chemistry", "dna_chemistry_1", "dna_chemistry_2", "dna_chemistry_3"};
   incompatible["dna_2"]  = {"dna_1", "dna",   "dna_3", "dna_4", "dna_5", "dna_6", "dna_7", "dna_chemistry", "dna_chemistry_1", "dna_chemistry_2", "dna_chemistry_3"};
@@ -342,10 +341,13 @@ BDSModularPhysicsList::BDSModularPhysicsList(const G4String& physicsList):
   incompatible["hadronic_elastic_xs"]   = {"hadronic_elastic",   "hadronic_elastic_d", "hadronic_elastic_h",  "hadronic_elastic_hp",   "hadronic_elastic_lend"};
   incompatible["ion_elastic"] = {"ion_elastic_qmd"};
   incompatible["ionisation"] = {"em", "em_ss", "em_1", "em_2", "em_3", "em_4", "em_livermore"};
+  incompatible["optical"] = {"cherenkov"};
   incompatible["qgsp_bert"]    = {"ftfp_bert", "ftfp_bert_hp", "ftf_bic", "qgsp_bert_hp", "qgsp_bic",     "qgsp_bic_hp"};
   incompatible["qgsp_bert_hp"] = {"ftfp_bert", "ftfp_bert_hp", "ftf_bic", "qgsp_bert",    "qgsp_bic",     "qgsp_bic_hp"};
   incompatible["qgsp_bic"]     = {"ftfp_bert", "ftfp_bert_hp", "ftf_bic", "qgsp_bert",    "qgsp_bert_hp", "qgsp_bic_hp"};
   incompatible["qgsp_bic_hp"]  = {"ftfp_bert", "ftfp_bert_hp", "ftf_bic", "qgsp_bert",    "qgsp_bert_hp", "qgsp_bic"};
+  incompatible["muon"] = {"em_extra"};
+  incompatible["muon_inelastic"] = {"em_extra", "muon"};
 
 #if G4VERSION_NUMBER > 1019
   for (const auto& name : {"em", "em_ss", "em_wvi", "em_1", "em_2", "em_3", "em_4"})

--- a/src/BDSModularPhysicsList.cc
+++ b/src/BDSModularPhysicsList.cc
@@ -514,6 +514,9 @@ void BDSModularPhysicsList::ConfigurePhysics()
 void BDSModularPhysicsList::ConfigureOptical()
 {
   G4long maxPhotonsPerStep = globals->MaximumPhotonsPerStep();
+  G4double maxBetaChangePerStep = globals->MaximumBetaChangePerStep();
+  if (maxBetaChangePerStep > 100.0)
+    {throw BDSException(__METHOD_NAME__, "the option 'maxBetaChangePerStep' must be less than 100 %");}
 #if G4VERSION_NUMBER < 1079
   // cherenkov turned on with optical even if it's not on as separate list
   opticalPhysics->Configure(G4OpticalProcessIndex::kCerenkov, true);
@@ -526,6 +529,7 @@ void BDSModularPhysicsList::ConfigureOptical()
   opticalPhysics->SetScintillationYieldFactor(globals->ScintYieldFactor());
   if (maxPhotonsPerStep >= 0)
     {opticalPhysics->SetMaxNumPhotonsPerStep(maxPhotonsPerStep);}
+  opticalPhysics->SetMaxBetaChangePerStep(maxBetaChangePerStep);
 #else
   G4OpticalParameters* opticalParameters = G4OpticalParameters::Instance();
   opticalParameters->SetProcessActivation(G4OpticalProcessName(G4OpticalProcessIndex::kCerenkov), true);
@@ -537,6 +541,7 @@ void BDSModularPhysicsList::ConfigureOptical()
   opticalParameters->SetProcessActivation(G4OpticalProcessName(G4OpticalProcessIndex::kWLS), true);
   if (maxPhotonsPerStep >= 0)
     {opticalParameters->SetCerenkovMaxPhotonsPerStep((G4int)maxPhotonsPerStep);}
+  opticalParameters->SetCerenkovMaxBetaChange(maxBetaChangePerStep);
 #endif
 }
 


### PR DESCRIPTION
For optical physics processes, they may suspend the parent trajectory. Generally, we don't interfere in the order of tracking in Geant4 (stacking) but it's completely valid to do so and typically done to see whether to continue simulating the event or abort it.

In any case, if you use optical physics or cherenkov physics just now and store trajectories, there will be an uncaught exception from map::at not finding the correct key in the depth and track ID maps. The current implementation assumes the trajectories are historically ordered.

This change, reimplements the depth map build up. Firstly, as we need three loops over the trajectories, the static cast from G4VTrajectory to BDSTrajectory is done first - then only the casted vector of pointers is used.

Secondly, the trackID map is made with one loop on its own.

Thirdly, the depth map is made by recursing up the trajectories (using the already made trackID map) to the primary to count the depth.  This works both in the case the trajectories are historically ordered and not.

Complexity-wise, 1 and 2 have no overhead. 3 now does N_depth x GetTrackID on each trajectory whereas before it would be 1x GetTrackID. Only for exceptionally deep trees might we see the overhead.