### PR TITLE
Fix the muon sweeper field for perfectly on axis particles.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_policy(SET CMP0057 NEW)
 if (CMAKE_VERSION VERSION_LESS 3.9.0)
   cmake_policy(SET CMP0042 OLD)
 endif()
+if (CMAKE_VERSION VERSION_GREATER 4.1.0)
+  # for FindROOT.cmake -> GCCXML which is deprecated in favour of CastXML.
+  cmake_policy(SET CMP0188 OLD)
+endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -12,7 +12,7 @@ if you'd like to give us feedback or help in the development.  See :ref:`support
 * Any aperture shape can be used for both the inside and the outside of a collimator.
 
 
-v1.8.0 - 2025 / XX / XX
+v1.8.0 - 2026 / XX / XX
 =======================
 
 The BDSIM source code has moved to Github and is available here: https://github.com/bdsim-collaboration/bdsim
@@ -57,6 +57,8 @@ New Features
 * The option :code:`cavityFieldType` may be used to set the default field model for all `rf`
   elements.
 * The "rfcavity" field is now "rfpillbox".
+* Fix a reference particle perfectly on axis in a muon sweeper field that would cause Nans
+  and crashes in tracking.
 
 **General**
 

--- a/src/BDSFieldMagMuonSpoiler.cc
+++ b/src/BDSFieldMagMuonSpoiler.cc
@@ -41,11 +41,17 @@ G4ThreeVector BDSFieldMagMuonSpoiler::GetField(const G4ThreeVector &position,
 { 
   G4double x = position.x();
   G4double y = position.y();
-  G4double r = std::hypot(x,y);
+  G4double r = std::hypot(std::abs(x), std::abs(y));
 
   G4ThreeVector localField;
-  localField[0] =  y/r * bField;
-  localField[1] = -x/r * bField;
+  G4double cyor = y/r;
+  if (std::isnan(cyor))
+    {cyor = 0;}
+  G4double cxor = -x/r;
+  if (std::isnan(cxor))
+    {cxor = 0;}
+  localField[0] = cyor * bField;
+  localField[1] = cxor * bField;
   localField[2] = 0;
 
   return localField;


### PR DESCRIPTION
At 0,0 transversely, the field would be undefined and would create nans that would be copied into tracking variables and then propagate along with the particle.  Ultimately, ruining tracking of that particle.