### PR TITLE
Fix issue 132

### DIFF
--- a/examples/features/components/jcoltip.gmad
+++ b/examples/features/components/jcoltip.gmad
@@ -17,7 +17,15 @@ l1: line=(d1, col1, d1, col2, d1, col3, d1, col4, d1, col5, d1, col6, d1, col7, 
 use, l1;
 
 beam, particle="e+",
-      energy=1*GeV,
+      energy=100*GeV,
       distrType="gauss",
       sigmaX = 2*cm,
       sigmaY = 2*cm;
+
+
+option, storeCollimatorInfo=1,
+        storeCollimatorHitsAll=1,
+        storeCollimatorHitsLinks=1;
+
+option, physicsList="g4FTFP_BERT",
+        minimumKineticEnergy=1*GeV;

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -152,6 +152,7 @@ Bug Fixes
 * Fixed possibly duplicated file extensions for text survey output.
 * Document the options :code:`maximumPhotonsPerStep` and :code:`maximumBetaChangePerStep` as well
   as fix their number type internally.
+* Fix a crash when using :code:`jcoltip` with collimator-specific output options.
 
 
 Output Changes

--- a/src/BDSBeamline.cc
+++ b/src/BDSBeamline.cc
@@ -978,6 +978,6 @@ std::vector<G4int> BDSBeamline::GetIndicesOfElementsOfType(const std::set<G4Stri
 
 std::vector<G4int> BDSBeamline::GetIndicesOfCollimators() const
 {
-  std::set<G4String> collimatorTypes = {"ecol", "rcol", "jcol", "crystalcol", "element-collimator"};
+  std::set<G4String> collimatorTypes = {"ecol", "rcol", "jcol", "jcoltip", "crystalcol", "element-collimator"};
   return GetIndicesOfElementsOfType(collimatorTypes);
 }


### PR DESCRIPTION
Fix an issue where BDSIM would crash with an exception from map:at if a sequence included a jcoltip with collimator-specific output options used as well.