### PR TITLE
Fix repeated transform3d

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -202,4 +202,4 @@ jobs:
 
           # run tests          
           cd /tmp/bdsim-build
-          ctest -j1
+          ctest -j1 --output-on-failure

--- a/manual/source/version_history.rst
+++ b/manual/source/version_history.rst
@@ -120,6 +120,7 @@ Bug Fixes
 * Fix :code:`transform3d` component applying offsets in a rotate frame that is not
   axis-aligned. It applied the offsets (dx, dy, dz) in the global axis and not the
   local ones.
+* Fix repeated transforms in a sequence. Previously, only the first one would be applied.
 * Fix rebdsim's Spectra command preparing the wrong variables when used on a cylindrical
   or spherical sampler where the variable is "totalEnergy" and not "energy".
 * Fix a bug where rebdsim would crash if a Spectra command was used on a cylindrical or

--- a/src/BDSBeamline.cc
+++ b/src/BDSBeamline.cc
@@ -570,7 +570,7 @@ void BDSBeamline::ApplyTransform3D(BDSTransform3D* component)
   
   // if not the first element in the beamline, get information from
   // the end of the last element in the beamline
-  if (!empty())
+  if (!empty() && !transformHasJustBeenApplied)
     {
       BDSBeamlineElement* last = back();
       previousReferenceRotationEnd = last->GetReferenceRotationEnd();


### PR DESCRIPTION
If one transform3d after another is used (or even more) only the first one would work until a regular element was added. This fixes it.