### PR TITLE
Add another linkdef to make sure there is at least one when USE_BOOST=OFF

### DIFF
--- a/include/BDSBH4DLinkDef.hh
+++ b/include/BDSBH4DLinkDef.hh
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#pragma link C++ class BDSBH4D<TH1D>+;
+
 #ifdef USE_BOOST
 #ifndef __ROOTDOUBLE__
 typedef double boost_histogram_storage_type;


### PR DESCRIPTION
When building with ROOT 6.40.00-rc1, I get:
```
FAILED: [code=1] root/BDSBH4DDict.cc root/BDSBH4DDict_rdict.pcm /bdsim/build/root/BDSBH4DDict.cc /bdsim/build/root/BDSBH4DDict_rdict.pcm
cd /bdsim/build && /usr/local/bin/rootcint -f /bdsim/build/root/BDSBH4DDict.cc -noIncludePaths -inlineInputHeader -D__ROOTBUILD__ -I/bdsim -I/bdsim/include -I/bdsim/parser/ /bdsim/include/BDSBH4D.hh /bdsim/include/BDSBH4DLinkDef.hh
Error: No selection rules specified and creation of C++ module not requested: did you forget to specify a selection file or to request the creation of a C++ module?
```

This is happening because when `USE_BOOST` is off there isn't any rule in
BDSBH4DLinkDef.hh. BDSBH4D inherits from BDSBH4DBase and has ClassDef(BDSBH4D,1)
outside any Boost guard, so the template always exists and always needs a
dictionary entry.