### PR TITLE
github : fail fast on build test actions

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -17,7 +17,7 @@ jobs:
     container: bdsim/${{ matrix.container }}:latest
      
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         container: [ubuntu20-g4.10.7, ubuntu20-g4.11.0, ubuntu20-g4.11.1, ubuntu20-g4.11.2, ubuntu20-g4.11.3,
                     ubuntu22-g4.10.7, ubuntu22-g4.11.0, ubuntu22-g4.11.1, ubuntu22-g4.11.2, ubuntu22-g4.11.3,
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         geant4-version: ["v10.7.4", "v11.0.4", "v11.1.3", "v11.2.2", "v11.3.2"]
         os: [macOS-14, macOS-15, macOS-15-intel]


### PR DESCRIPTION
Allow the GitHub actions to stop on first failure. Reduced resources