### PR TITLE
Cumulative Compton Seg Fault Fix

### DIFF
--- a/src/BDSLaserCumulativeCompton.cc
+++ b/src/BDSLaserCumulativeCompton.cc
@@ -100,7 +100,9 @@ G4VParticleChange* BDSLaserCumulativeCompton::PostStepDoIt(const G4Track& track,
 
   /////////////////////////////// Get Particle Info //////////////////////////
   BDSUserTrackInformation* trackInfo = dynamic_cast<BDSUserTrackInformation*>(track.GetUserInformation());
-  if (trackInfo->GetComptonScattered())
+  if (!trackInfo)
+    {return pParticleChange;}
+  else if (trackInfo->GetComptonScattered())
     {return pParticleChange;}
   else
     {

--- a/src/BDSTrackingAction.cc
+++ b/src/BDSTrackingAction.cc
@@ -36,8 +36,6 @@ along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <set>
 
-#include "BDSEventInfo.hh"
-
 class G4LogicalVolume;
 
 
@@ -117,11 +115,11 @@ void BDSTrackingAction::PreUserTrackingAction(const G4Track* track)
   const G4ParticleDefinition *particle = track->GetParticleDefinition();
   G4ProcessManager* pmanager = particle->GetProcessManager();
   G4VProcess* process = pmanager->GetProcess("laserCumulativeCompton");
-  
+
   if (process)
-  {
-    auto* trackInfo = new BDSUserTrackInformation(track->GetDynamicParticle(), defaultPolarisation);
-    track->SetUserInformation(trackInfo);
+    {
+      auto* trackInfo = new BDSUserTrackInformation(track->GetDynamicParticle(), defaultPolarisation);
+      track->SetUserInformation(trackInfo);
     }
 }
 

--- a/src/BDSTrackingAction.cc
+++ b/src/BDSTrackingAction.cc
@@ -36,6 +36,8 @@ along with BDSIM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <set>
 
+#include "BDSEventInfo.hh"
+
 class G4LogicalVolume;
 
 
@@ -110,6 +112,16 @@ void BDSTrackingAction::PreUserTrackingAction(const G4Track* track)
     {
       auto* trackInfo = new BDSUserTrackInformation(track->GetDynamicParticle(), defaultPolarisation);
       track->SetUserInformation(trackInfo);
+    }
+
+  const G4ParticleDefinition *particle = track->GetParticleDefinition();
+  G4ProcessManager* pmanager = particle->GetProcessManager();
+  G4VProcess* process = pmanager->GetProcess("laserCumulativeCompton");
+  
+  if (process)
+  {
+    auto* trackInfo = new BDSUserTrackInformation(track->GetDynamicParticle(), defaultPolarisation);
+    track->SetUserInformation(trackInfo);
     }
 }
 


### PR DESCRIPTION
Adding a filter for including BDSTrackInfo for all cases of laser cumulative inverse-Compton scattering to fix segfault from recent merge.

If statement wrapping addition of BDSTrackInfo to all cases of cumulative inverse-Compton scattering added based upon the process used.

This was previously achieved by adding the BDSTrackInfo to all particles. The most recent merge applied BDSTrack info only to Ions. 

Filtering by process stops the segfault in BDSLaserCumulativeCompton.cc. 