### PR TITLE
Skip BDSBH4D dictionary when USE_BOOST is off

### DIFF
--- a/cmake/ROOT.cmake
+++ b/cmake/ROOT.cmake
@@ -10,6 +10,13 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/root)
 file(GLOB linkHeaders ${CMAKE_CURRENT_SOURCE_DIR}/include/*LinkDef.hh)
 # for loop over link definitions
 foreach(header ${linkHeaders})
+  # The BDSBH4D dictionary only carries Boost-based 4D-histogram classes; its
+  # LinkDef is entirely #ifdef USE_BOOST. Without Boost it preprocesses to an
+  # empty selection file, which ROOT >= 6.40 rejects ("No selection rules
+  # specified"). Skip generating it when Boost support is off.
+  if(NOT USE_BOOST AND header MATCHES "BDSBH4DLinkDef")
+    continue()
+  endif()
   # remove LinkDef.hh
   string(FIND ${header} "LinkDef.hh" pos REVERSE)
   string(FIND ${header} "/" dir REVERSE)


### PR DESCRIPTION
The BDSBH4D dictionary only carries Boost-based 4D-histogram classes and its LinkDef (include/BDSBH4DLinkDef.hh) is entirely wrapped in `#ifdef USE_BOOST`. When BDSIM is configured without Boost the LinkDef preprocesses to an empty selection file, which older ROOT tolerated but ROOT >= 6.40 rejects with:

    Error: No selection rules specified and creation of C++ module not
    requested: did you forget to specify a selection file ...

Skip generating that dictionary when Boost support is off. All BDSBH4D usage elsewhere is already guarded by `#ifdef USE_BOOST`, so this is consistent with the rest of the no-Boost build.

Found in https://github.com/conda-forge/bdsim-g4-feedstock/pull/12