### PR TITLE
isFinite tolerance sigma55

### DIFF
--- a/src/BDSBunchGaussMatrix.cc
+++ b/src/BDSBunchGaussMatrix.cc
@@ -58,7 +58,7 @@ void BDSBunchGaussMatrix::SetOptions(const BDSParticleDefinition* beamParticle,
   sigmaGM[4][4] = beam.sigma55;
   sigmaGM[4][5] = beam.sigma56;
   sigmaGM[5][5] = beam.sigma66;
-  if (BDS::IsFinite(beam.sigma55))
+  if (BDS::IsFinite(beam.sigma55, 1e-50))
     {finiteSigmaT = true;}
   if (BDS::IsFinite(beam.sigma66))
     {finiteSigmaE = true;}


### PR DESCRIPTION
Changing the isFinite tolerance value to account for very small numbers. sigma_55 would be 1e-18 for a normal sigma_t in a particle bunch of 1 ns, this was smaller than the previous tolerance. Tolerance updated to 1e-50. 